### PR TITLE
fix(search_doc): pass sentence meta to the template

### DIFF
--- a/search/web_app/views.py
+++ b/search/web_app/views.py
@@ -422,7 +422,8 @@ def search_doc():
                                                corpusSize=settings.corpus_size)
     hitsProcessed['media'] = settings.media
     hitsProcessed['images'] = settings.images
-    return render_template('search_results/result_docs.html', data=hitsProcessed)
+    return render_template('search_results/result_docs.html', data=hitsProcessed,
+                           sentence_meta=settings.sentence_meta)
 
 
 @app.route('/autocomplete_meta/<metafield>')


### PR DESCRIPTION
I am almost sure that this parameter is needed for substitution in `search/web_app/templates/search_results/result_docs.html`.